### PR TITLE
Add `Course Revision Number` to `Course Outline`.

### DIFF
--- a/src/course-home/data/__snapshots__/redux.test.js.snap
+++ b/src/course-home/data/__snapshots__/redux.test.js.snap
@@ -453,6 +453,7 @@ Object {
             "url": "https://example.com/bookmarks",
           },
         ],
+        "courseRevision": "2023.10",
         "datesBannerInfo": Object {
           "contentTypeGatingEnabled": false,
           "missedDeadlines": false,

--- a/src/course-home/data/api.js
+++ b/src/course-home/data/api.js
@@ -420,6 +420,7 @@ export async function getOutlineTabData(courseId) {
   const courseBlocks = data.course_blocks ? normalizeOutlineBlocks(courseId, data.course_blocks.blocks) : {};
   const courseGoals = camelCaseObject(data.course_goals);
   const courseTools = camelCaseObject(data.course_tools);
+  const courseRevision = camelCaseObject(data.course_revision);
   const datesBannerInfo = camelCaseObject(data.dates_banner_info);
   const datesWidget = camelCaseObject(data.dates_widget);
   const enrollAlert = camelCaseObject(data.enroll_alert);
@@ -441,6 +442,7 @@ export async function getOutlineTabData(courseId) {
     courseBlocks,
     courseGoals,
     courseTools,
+    courseRevision,
     datesBannerInfo,
     datesWidget,
     enrollAlert,

--- a/src/course-home/outline-tab/OutlineTab.jsx
+++ b/src/course-home/outline-tab/OutlineTab.jsx
@@ -10,6 +10,7 @@ import { AlertList } from '../../generic/user-messages';
 import CourseDates from './widgets/CourseDates';
 import CourseGoalCard from './widgets/CourseGoalCard';
 import CourseHandouts from './widgets/CourseHandouts';
+import CourseRevision from './widgets/CourseRevision';
 import CourseTools from './widgets/CourseTools';
 import { fetchOutlineTab } from '../data';
 import genericMessages from '../../generic/messages';
@@ -246,6 +247,9 @@ function OutlineTab({ intl }) {
               mmp2p={MMP2P}
             />
             <CourseHandouts
+              courseId={courseId}
+            />
+            <CourseRevision
               courseId={courseId}
             />
           </div>

--- a/src/course-home/outline-tab/messages.js
+++ b/src/course-home/outline-tab/messages.js
@@ -70,6 +70,10 @@ const messages = defineMessages({
     id: 'learning.outline.resume',
     defaultMessage: 'Resume course',
   },
+  revision: {
+    id: 'learning.outline.revision',
+    defaultMessage: 'Course Version',
+  },
   setGoal: {
     id: 'learning.outline.setGoal',
     defaultMessage: 'To start, set a course goal by selecting the option below that best describes your learning plan.',

--- a/src/course-home/outline-tab/widgets/CourseRevision.jsx
+++ b/src/course-home/outline-tab/widgets/CourseRevision.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+
+import messages from '../messages';
+import { useModel } from '../../../generic/model-store';
+
+function CourseRevision({ courseId, intl }) {
+  const {
+    courseRevision,
+  } = useModel('outline', courseId);
+
+  if (!courseRevision) {
+    return null;
+  }
+
+  return (
+    <section className="mb-4">
+      <h2 className="h4">{intl.formatMessage(messages.revision)}</h2>
+      <span>{courseRevision}</span>
+    </section>
+  );
+}
+
+CourseRevision.propTypes = {
+  courseId: PropTypes.string.isRequired,
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(CourseRevision);


### PR DESCRIPTION
Ref edx-platform change: https://github.com/CUCWD/edx-platform/pull/212

Needed a way to apply a version number to a course to ensure that the learner has a specific version of the course.

This was a request from the `Choose Aerospace` administers to ensure that the schools are using the latest version.

Adding this number into the course is found on the Schedule & Details page Course Details section (new field highlighted below).
 
![image](https://github.com/CUCWD/edx-platform/assets/5641338/d255ad33-5ab7-4161-9787-f3896437482f)

If there is a course that has a Course Revision Number then it will show up on the LMS Course Outline  page like so (e.g. Version: ABC. If we haven't specified a number then it will not appear on the course meta information. See the Template: Mathematics course below for an example of where we've added this number.

![image](https://github.com/CUCWD/frontend-app-learning/assets/5641338/d57af2d2-d63f-4824-acc1-17e8fa1bb92d)
