### PR TITLE
Align the `subsection` sequences by indenting them underneath the `section` names.

### DIFF
--- a/src/course-home/outline-tab/SequenceLink.jsx
+++ b/src/course-home/outline-tab/SequenceLink.jsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import EffortEstimate from '../../shared/effort-estimate';
 import { useModel } from '../../generic/model-store';
 import messages from './messages';
+import './SequenceLink.scss';
 
 function SequenceLink({
   id,
@@ -52,7 +53,7 @@ function SequenceLink({
   return (
     <li>
       <div className={classNames('', { 'mt-2 pt-2 border-top border-light': !first })}>
-        <div className="row w-100 m-0">
+        <div className="row w-100 m-0 sequence-indent">
           <div className="col-auto p-0">
             {complete ? (
               <FontAwesomeIcon

--- a/src/course-home/outline-tab/SequenceLink.scss
+++ b/src/course-home/outline-tab/SequenceLink.scss
@@ -1,0 +1,3 @@
+.sequence-indent {
+    padding-left: 2.75rem !important 
+}


### PR DESCRIPTION
Verified that the instructional design team would like the the `subsection` sequences indented. This will allow for visual separation of the content and provide better nesting.

I tried using bootstrap spacing https://getbootstrap.com/docs/4.3/utilities/spacing/ of `pl-5` but it was too far in for the indent and I needed to specify an exact value to align the checkmark progress with the title of the section name.

Ref: https://github.com/CUCWD/frontend-app-learning/issues/25