### PR TITLE
Upgrade `@edx/brand` to point to EducateWorkforce version for nutmeg release.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
-        "@edx/frontend-component-footer": "10.2.2",
+        "@edx/brand": "npm:@cucwd-prod/brand-educateworkforce@^2.1.2-nutmeg.2.1",
+        "@edx/frontend-component-footer": "^10.2.2",
         "@edx/frontend-component-header": "2.4.6",
         "@edx/frontend-lib-special-exams": "1.16.3",
         "@edx/frontend-platform": "1.15.6",
@@ -56,6 +56,9 @@
         "jest": "27.5.1",
         "rosie": "2.1.0"
       }
+    },
+    "brand-educateworkforce": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.1",
@@ -2732,10 +2735,10 @@
       }
     },
     "node_modules/@edx/brand": {
-      "name": "@edx/brand-openedx",
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
-      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+      "name": "@cucwd-prod/brand-educateworkforce",
+      "version": "2.1.2-nutmeg.2.1",
+      "resolved": "https://registry.npmjs.org/@cucwd-prod/brand-educateworkforce/-/brand-educateworkforce-2.1.2-nutmeg.2.1.tgz",
+      "integrity": "sha512-NvfpmP/SdPpUfiBgdO37DU67kqYPXmnmefBfXfVCrhhuTN6Vcohazqu7vA76tkHeMLaCvtXvTlbL5V3ESwr3kw=="
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.0.2",
@@ -30323,9 +30326,9 @@
       "dev": true
     },
     "@edx/brand": {
-      "version": "npm:@edx/brand-openedx@1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
-      "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ=="
+      "version": "npm:@cucwd-prod/brand-educateworkforce@2.1.2-nutmeg.2.1",
+      "resolved": "https://registry.npmjs.org/@cucwd-prod/brand-educateworkforce/-/brand-educateworkforce-2.1.2-nutmeg.2.1.tgz",
+      "integrity": "sha512-NvfpmP/SdPpUfiBgdO37DU67kqYPXmnmefBfXfVCrhhuTN6Vcohazqu7vA76tkHeMLaCvtXvTlbL5V3ESwr3kw=="
     },
     "@edx/browserslist-config": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "url": "https://github.com/edx/frontend-app-learning/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
-    "@edx/frontend-component-footer": "10.2.2",
+    "@edx/brand": "npm:@cucwd-prod/brand-educateworkforce@^2.1.2-nutmeg.2.1",
+    "@edx/frontend-component-footer": "^10.2.2",
     "@edx/frontend-component-header": "2.4.6",
     "@edx/frontend-lib-special-exams": "1.16.3",
     "@edx/frontend-platform": "1.15.6",

--- a/src/course-home/outline-tab/SequenceLink.jsx
+++ b/src/course-home/outline-tab/SequenceLink.jsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import EffortEstimate from '../../shared/effort-estimate';
 import { useModel } from '../../generic/model-store';
 import messages from './messages';
+import './SequenceLink.scss';
 
 function SequenceLink({
   id,
@@ -52,7 +53,7 @@ function SequenceLink({
   return (
     <li>
       <div className={classNames('', { 'mt-2 pt-2 border-top border-light': !first })}>
-        <div className="row w-100 m-0">
+        <div className="row w-100 m-0 sequence-indent">
           <div className="col-auto p-0">
             {complete ? (
               <FontAwesomeIcon

--- a/src/course-home/outline-tab/SequenceLink.scss
+++ b/src/course-home/outline-tab/SequenceLink.scss
@@ -1,0 +1,3 @@
+.sequence-indent {
+    padding-left: 2.75rem !important 
+}

--- a/src/generic/PageLoading.jsx
+++ b/src/generic/PageLoading.jsx
@@ -22,7 +22,7 @@ export default class PageLoading extends Component {
         <div
           className="d-flex justify-content-center align-items-center flex-column"
           style={{
-            height: '50vh',
+            height: '89vh',
           }}
         >
           <Spinner animation="border" variant="primary" screenReaderText={this.renderSrMessage()} />


### PR DESCRIPTION
- Upgrade `@edx/brand` to point to EducateWorkforce branding
- Setup a stick footer on PageLoading by increasing the page vertical height.
- Tab in the course outline sequential pages.